### PR TITLE
Show feedback when persist scenes

### DIFF
--- a/src/app/shared/utils/promise-progress-monitor.spec.ts
+++ b/src/app/shared/utils/promise-progress-monitor.spec.ts
@@ -1,0 +1,121 @@
+import { PromiseProgressMonitor } from "./promise-progress-monitor";
+
+describe('PromiseProgressMonitor', () => {
+  it('#initialize', () => {
+    const promiseProgressMonitor = new PromiseProgressMonitor();
+    expect(promiseProgressMonitor.count).toEqual(0);
+    expect(promiseProgressMonitor.settled).toEqual(0);
+    expect(promiseProgressMonitor.settledPercent).toEqual(0);
+    expect(promiseProgressMonitor.lastSettledTask).toBeUndefined();
+  });
+
+  it('#add should increment the tasks count', () => {
+    const promiseProgressMonitor = new PromiseProgressMonitor();
+
+    promiseProgressMonitor.add("task0", new Promise(() => { }));
+    expect(promiseProgressMonitor.count).toEqual(1);
+
+    promiseProgressMonitor.add("task1", new Promise(() => { }));
+    expect(promiseProgressMonitor.count).toEqual(2);
+  });
+
+  it('#add chained should increment the tasks count', () => {
+    const promiseProgressMonitor = new PromiseProgressMonitor();
+
+    promiseProgressMonitor
+      .add("task0", new Promise(() => { }))
+      .then("task1", () => new Promise(() => { }))
+      .then("task2", () => new Promise(() => { }));
+
+      expect(promiseProgressMonitor.count).toEqual(3);
+  });
+
+  it('#add should raise onProgressChange event', () => {
+    const promiseProgressMonitor = new PromiseProgressMonitor();
+
+    const onProgressEventListener = jasmine.createSpy();
+
+    promiseProgressMonitor.onProgressChange(onProgressEventListener);
+    expect(onProgressEventListener).not.toHaveBeenCalled();
+
+    promiseProgressMonitor.add("task0", new Promise(() => { }));
+    expect(onProgressEventListener).toHaveBeenCalledTimes(1);
+
+    promiseProgressMonitor.add("task1", new Promise(() => { }));
+    expect(onProgressEventListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('completed promises should increase settled tasks', async () => {
+    const promiseProgressMonitor = new PromiseProgressMonitor();
+
+    let deferredTask0;
+    let deferredTask1;
+    let deferredTask2;
+
+    promiseProgressMonitor
+      .add("task0", new Promise((resolve) => { deferredTask0 = resolve}))
+      .then("task1", () => new Promise((resolve) => { deferredTask1 = resolve}))
+      .then("task2", () => new Promise((resolve) => { deferredTask2 = resolve}));
+
+      expect(promiseProgressMonitor.settled).toEqual(0);
+      expect(promiseProgressMonitor.settledPercent).toEqual(0);
+      expect(promiseProgressMonitor.lastSettledTask).toBeUndefined();
+
+      deferredTask0();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(promiseProgressMonitor.settled).toEqual(1);
+      expect(promiseProgressMonitor.settledPercent).toEqual(100 / 3);
+      expect(promiseProgressMonitor.lastSettledTask).toEqual("task0");
+
+      deferredTask1();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(promiseProgressMonitor.settled).toEqual(2);
+      expect(promiseProgressMonitor.settledPercent).toEqual(2 * 100 / 3);
+      expect(promiseProgressMonitor.lastSettledTask).toEqual("task1");
+
+      deferredTask2();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(promiseProgressMonitor.settled).toEqual(3);
+      expect(promiseProgressMonitor.settledPercent).toEqual(100);
+      expect(promiseProgressMonitor.lastSettledTask).toEqual("task2");
+  });
+
+  it('completed promises should raise onProgressChange event', async () => {
+    const promiseProgressMonitor = new PromiseProgressMonitor();
+
+    let deferredTask0;
+    let deferredTask1;
+    let deferredTask2;
+
+    promiseProgressMonitor
+      .add("task0", new Promise((resolve) => { deferredTask0 = resolve}))
+      .then("task1", () => new Promise((resolve) => { deferredTask1 = resolve}))
+      .then("task2", () => new Promise((resolve) => { deferredTask2 = resolve}));
+
+    let expectedSettled = 1;
+    let expectedPercent = 100 / 3;
+    let expectedLastSettledTask = "task0";
+
+    promiseProgressMonitor.onProgressChange((monitor) => {
+      expect(promiseProgressMonitor.settled).toEqual(expectedSettled);
+      expect(promiseProgressMonitor.settledPercent).toEqual(expectedPercent);
+      expect(promiseProgressMonitor.lastSettledTask).toEqual(expectedLastSettledTask);
+    });
+
+    deferredTask0();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expectedSettled = 2;
+    expectedPercent = 2 * 100 / 3;
+    expectedLastSettledTask = "task1";
+    deferredTask1();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expectedSettled = 3;
+    expectedPercent = 100;
+    expectedLastSettledTask = "task2";
+    deferredTask2();
+  });
+});

--- a/src/app/shared/utils/promise-progress-monitor.ts
+++ b/src/app/shared/utils/promise-progress-monitor.ts
@@ -1,0 +1,59 @@
+import EventEmitter from "events";
+
+export class PromiseProgressMonitor {
+  private _tasksCount = 0;
+  private _settledTasksCount = 0
+  private _lastSettledTask = undefined;
+  private _eventEmitter = new EventEmitter();
+
+  add<T>(taskName: string, promise : Promise<T>) {
+    return new PromiseProgressMonitor.Chain<T>(
+      this,
+      this.addUnchained(taskName, promise));
+  }
+
+  addUnchained<T>(taskName: string, promise : Promise<T>) : Promise<T> {
+    this._tasksCount++;
+    this._eventEmitter.emit('progressChange', this);
+    return promise.finally(() => {
+      this._settledTasksCount++;
+      this._lastSettledTask = taskName;
+      this._eventEmitter.emit('progressChange', this);
+    });
+  }
+
+  onProgressChange(listener : ((value: PromiseProgressMonitor) => void) ){
+    this._eventEmitter.on("progressChange", listener);
+  }
+
+  get settled() : number {
+    return this._settledTasksCount;
+  }
+
+  get count() : number {
+    return this._tasksCount;
+  }
+
+  get lastSettledTask() : string | undefined {
+    return this._lastSettledTask;
+  }
+
+  get settledPercent() : number {
+    return this.count == 0 ? 0 : this.settled * 100 / this.count;
+  }
+
+  public static Chain = class<T> {
+    constructor(private _tracker : PromiseProgressMonitor, private _promise : Promise<T>) {
+    }
+
+    then<TResult = T>(taskName: string, onfulfilled: ((value: T) => TResult | PromiseLike<TResult>)) : InstanceType<typeof PromiseProgressMonitor.Chain<TResult>> {
+      return new PromiseProgressMonitor.Chain<TResult>(
+        this._tracker,
+        this._tracker.addUnchained(taskName, this._promise.then(onfulfilled)));
+    }
+
+    unwrap() : Promise<T> {
+      return this._promise;
+    }
+  }
+}


### PR DESCRIPTION
When a new scene is create with many columns, it can take several minutes to index all columns and without showing any feedback. The only possible feedback is to inspect the network requests and check the progress of the pending requests (but I need to open the inspect tool before click on load data button).

As I am using koia to analyse datasets with many variables (around 1000), the lack of feedback sometimes makes me wonder if it stills working, then I implemented a feedback mechanism that monitors the progress of promises on my fork.

The implementation wraps the promises and attach a finally that monitors when the tasks is ended. For better feedback, the promise progress monitor receives a task name and stores the latest settled task.

I decided to open this PR because I believe it can be a nice user experience improvement for everyone using koia.
